### PR TITLE
Delete command and watch persist attribute

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ bin/pip3
 bin/pip3.6
 bin/python
 bin/python3
+utils.py

--- a/.gitignore
+++ b/.gitignore
@@ -131,4 +131,4 @@ bin/pip3
 bin/pip3.6
 bin/python
 bin/python3
-utils.py
+data/db.pickle.prod

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Python: Current File",
+            "name": "Python: tg_bot_service.py",
             "type": "python",
             "request": "launch",
             "program": "tg_bot_service.py",

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,56 @@
+# TODO.md - Planned enhancements.
+
+## Persistent watches and alerts
+
+Ability to mark a watch or an alert as "persistent" so that it doesn't get deleted.
+
+* DONE Way to delete watches and alerts as they won't disappear naturally now
+* Modification to the list and show commands that mentions if they are persistent and gives the details of expiry date
+* Way to mark a watch or alert as persistent, by assing a parameter to the command such as "persistent" or "persist" or "persist 1 month" or "persist forever". Thereby having an end date which will default to 1 year.
+* An automated way to clean up expired persistents, with a notification so that the user knows the persistent expired. Preferablly with a warnings to that they can elect to extend it. 
+* This means it needs a way to edit alerts, but I don't want to do that. Too much work.
+* Way to store that watches or alerts are persistent, including when the last triggered. This is going to have to be a new separate data structure because watches and alerts are so different. It will be a dictionary tree structure with chatID at the top level, then watch/alert hash as the key at the next level, then a dictionary with persistence information:.
+Example: {chatID: 123456789: {watchHash1: {persistent: True, last_triggered: 1234567890, expires: 1234567890}, watchHash2: {persistent: False, last_triggered: 1234567890, expires: 1234567890}}}
+* Way to prevent persistent alerts triggering too often, such as by making a minimum period between notifications, either static (one day), definable ("persistant 1 day") or dynamic based on the scale of the watch or alert
+* The persistent data will be a separate data structure but in the same object, so at the same level as the existing alerts and watches structures.
+* No separate commands will be added appart from the delete which is already done, everything else is an addon to existing commands such as creating commands now having a "persistant" qualifier, and list and show commands displaying that info about persistance of each line item.
+* The cleanup of expirary should happen once per day, and the user should be notified of the expirary of each persistent alert.
+* Command syntax for persistant will just be an additional word on the end of the existing line, I'll leave differing periods to a future update and just consider the default to be 1 daily notification and expirary of one year.
+* Warnings and options on expirary will be left to a later version.
+
+## "Bullish" watch
+
+A watch for a bullish period of the market, when the price goes up and stays up for a period y.
+
+
+## "Bearish
+
+## "Boring" watch
+
+A watch for a "boring" period of the market, otherwise known as crabbing, when the price stays within a narrow range x% for a period y.
+
+
+## "Bullish" watch
+
+A watch for a bullish period of the market, when the price goes up and stays up for a period y.
+
+
+## "Bearish" watch
+
+A watch for a bearish period of the market, when the price consistently goes down and stays down for a period y.
+
+
+## "Bullish" alert
+
+An alert for a bullish period of the market, when the price goes up and stays up for a period y.
+
+
+## "Bearish" alert
+
+An alert for a bearish period of the market, when the price consistently goes down and stays down for a period y.
+
+## Trailing stop loss alert
+
+An alert that happens when the price falls x% below the recent ATH for a certain period or averaged or smoothed. It is an indication of time to sell.
+
+

--- a/botfather.txt
+++ b/botfather.txt
@@ -1,0 +1,15 @@
+price - Get the price for desired coin
+chart - Get chart for a coin at a timeframe 
+top - See the current prices of the top coins and market cap.
+lower - Get notified when price of desired symbol goes LOWER than specified number
+higher - Get notified when price of desired symbol goes HIGHER than specified number.
+alerts - Get the current alerts.
+clear - Clear current alerts.
+yesterday - Price yesterday for a coin
+history - Historical price of a coin in the past. Supports days, weeks, months, years.
+dropby - Check if a coin has dropped by a percentage
+watch - Watch for coin to drop or rise by amount or percentage over period exact
+showwatches - Show the watches
+ath - What is the ATH of a coin (only checks back to Oct 2021)
+delete - Delete one alert or watch by ID. Use without param for list of IDs.
+help - See detailed help with examples

--- a/command_handler.py
+++ b/command_handler.py
@@ -273,8 +273,12 @@ class CommandHandler:
             duration_type = 'days'
             persistence = True
             notify_frequency = 24 * 60 * 60 # 24 hours
-            if len(parts) > 6 and parts[6] in frequency_mapping:
-                notify_frequency = frequency_mapping[parts[6]]
+            if len(parts) > 6:
+                if parts[6] in frequency_mapping:
+                    notify_frequency = frequency_mapping[parts[6]]
+                else:
+                    self.api.sendMessage("Invalid frequency, must be minute, hourly, daily, weekly", chatId)
+                    return
 
         # if there are 6 or 7 parts and the last part starts 'persist' then persistence is true
         persistence = False
@@ -283,6 +287,9 @@ class CommandHandler:
             notify_frequency = 24 * 60 * 60 # 24 hours
             if parts[7] in frequency_mapping:
                 notify_frequency = frequency_mapping[parts[7]]
+            else:
+                self.api.sendMessage("Invalid frequency, must be minute, hourly, daily, weekly", chatId)
+                return
                 
 
 

--- a/command_handler.py
+++ b/command_handler.py
@@ -91,7 +91,7 @@ class CommandHandler:
                         hashOfWatch = get_id(chatId,watch)[:4]
                         # persistString is either blank or the word "persistent" followed by the notification frequency
                         if 'persistent' in watch and watch['persistent']:
-                            persistString =f'persistent {watch["notify_frequencey"]} seconds'
+                            persistString =f'persistent {watch["notify_frequency"]} seconds'
                         else:
                             persistString = ''
                         
@@ -183,10 +183,10 @@ class CommandHandler:
         msg = ''
         for watch in self.db['watches']:
             if watch['chatId'] == chatId:
-                # persistString is either empty or it the word "persistent" followed by the notify_frequencey duration
+                # persistString is either empty or it the word "persistent" followed by the notify_frequency duration
                 persistString = ''
                 if 'persistent' in watch and watch['persistent']:
-                    persistString =f'persistent {watch["notify_frequencey"]} seconds'
+                    persistString =f'persistent {watch["notify_frequency"]} seconds'
                 msg += '{} {} {} {} {} {}\n'.format(watch['fsym'], watch['op'], watch['target'], watch['duration'], watch['duration_type'], persistString)
         
                 
@@ -284,7 +284,7 @@ class CommandHandler:
         watch['persistent'] = persistence
         watch['last_notify'] = 0 # Zero epoch
         # once per 24 hours as default
-        watch['notify_frequencey']  = 24 * 60 * 60
+        watch['notify_frequency']  = 24 * 60 * 60
 
 
         if 'watches' not in self.db:

--- a/command_handler.py
+++ b/command_handler.py
@@ -134,7 +134,7 @@ class CommandHandler:
                                 if deleteID == hashOfAlert:
                                     self.db['alerts'][chatId][fsym][op][tsym].remove(target)
                                     self.api.sendMessage("Done", chatId)
-                                    self.logger.info(f'Alert deleted {alertString}')
+                                    self.log.info(f'Alert deleted {alertString}')
                                     return
 
             # now the watches
@@ -146,7 +146,7 @@ class CommandHandler:
                         if deleteID == hashOfWatch:
                             self.db['watches'].remove(watch)
                             self.api.sendMessage("Done", chatId)
-                            self.logger.info(f'Watch deleted {watch}')
+                            self.log.info(f'Watch deleted {watch}')
                             return
                         
             self.api.sendMessage('Not found', chatId)

--- a/command_handler.py
+++ b/command_handler.py
@@ -1,4 +1,4 @@
-import math, time, requests, pickle, traceback, hashlib
+import math, time, requests, pickle, traceback
 from datetime import datetime, timedelta
 
 
@@ -11,7 +11,7 @@ import config
 from formating import format_price
 from api.binance_rest import CandleInterval
 
-
+from utils import get_id
 
 class CommandHandler:
 
@@ -78,8 +78,8 @@ class CommandHandler:
                     for op in alerts[fsym]:
                         for tsym in alerts[fsym][op]:
                             for target in alerts[fsym][op][tsym]:
+                                hashOfAlert = get_id(chatId, target)[:4]
                                 alertString = f'{fsym} {op} {target} {tsym}\n' 
-                                hashOfAlert = hashlib.sha256(alertString.encode('utf-8')).hexdigest()[:4]
                                 deleteList += f'ID={hashOfAlert} : {alertString} \n'
             else:
                 deleteList += 'No alert is set'
@@ -88,8 +88,8 @@ class CommandHandler:
             if 'watches' in self.db:
                 for watch in self.db['watches']:
                     if watch['chatId'] == chatId:
+                        hashOfWatch = get_id(chatId,watch)[:4]
                         watchString = f'{watch["fsym"]} {watch["op"]} {watch["target"]} {watch["duration"]} {watch["duration_type"]}'
-                        hashOfWatch = hashlib.sha256(watchString.encode('utf-8')).hexdigest()[:4]
                         deleteList += f'ID={hashOfWatch} : {watchString} \n'
                         
             else:
@@ -124,7 +124,7 @@ class CommandHandler:
                         for tsym in alerts[fsym][op]:
                             for target in alerts[fsym][op][tsym]:
                                 alertString = f'{fsym} {op} {target} {tsym}\n' 
-                                hashOfAlert = hashlib.sha256(alertString.encode('utf-8')).hexdigest()[:4]
+                                hashOfAlert = get_id(chatId, target)[:4]
                                 if deleteID == hashOfAlert:
                                     self.db['alerts'][chatId][fsym][op][tsym].remove(target)
                                     self.api.sendMessage("Done", chatId)
@@ -136,7 +136,7 @@ class CommandHandler:
                 for watch in self.db['watches']:
                     if watch['chatId'] == chatId:
                         watchString = f'{watch["fsym"]} {watch["op"]} {watch["target"]} {watch["duration"]} {watch["duration_type"]}'
-                        hashOfWatch = hashlib.sha256(watchString.encode('utf-8')).hexdigest()[:4]
+                        hashOfWatch = get_id(chatId, watch)[:4]
                         if deleteID == hashOfWatch:
                             self.db['watches'].remove(watch)
                             self.api.sendMessage("Done", chatId)

--- a/command_handler.py
+++ b/command_handler.py
@@ -82,7 +82,7 @@ class CommandHandler:
                                 alertString = f'{fsym} {op} {target} {tsym}\n' 
                                 deleteList += f'ID={hashOfAlert} : {alertString} \n'
             else:
-                deleteList += 'No alert is set'
+                deleteList += 'No alert is set \n\n'
 
             # now the watches
             if 'watches' in self.db:

--- a/help.md
+++ b/help.md
@@ -90,6 +90,13 @@ What is the ATH of a coin (only checks back to Oct 2021)
 
 `/ath BTC`
 
+**/delete**
+Delete alerts or watches.
+
+`/delete` Show list of alerts and watches with delete IDs.
+
+`/delete 1234` Delete alert or watch with ID 1234.
+
 
 **/help**  
 See this message.

--- a/help.md
+++ b/help.md
@@ -45,10 +45,7 @@ Get the current alerts.
 
 **/clear**  
 Clear current alerts.
-
-**/yesterday**
-Price yesterday for a coin
-
+ 
 **/history**
 Historical price of a coin in the past. Supports days, weeks, months, years.
 

--- a/help.md
+++ b/help.md
@@ -79,6 +79,14 @@ Example:
 `/watch btc drop 5000 2 days` (absolute value drop)  
 `/watch btc drop 5000 from ath`  
 `/watch btc drop 75% from ath`  
+
+Optionally watch commands have have a "persist" keywords so they don't get deleted when they fire
+but will repeat. Minimum frequency is default 1 day. Such watches have to be manually deleted
+using the `/delete` command when you don't want them any more.
+
+Example:
+`/watch btc drop 50% 14 days persist`
+
   
 Comparisons are vs current price unless "from ath" is set   
 

--- a/help.md
+++ b/help.md
@@ -81,12 +81,12 @@ Example:
 `/watch btc drop 75% from ath`  
 
 Optionally watch commands have have a "persist" keywords so they don't get deleted when they fire
-but will repeat. Minimum frequency is default 1 day. Such watches have to be manually deleted
+but will repeat. Minimum frequency is default 1 day but can be set to hourly, weekly or by the minute. Such watches have to be manually deleted
 using the `/delete` command when you don't want them any more.
 
 Example:
 `/watch btc drop 50% 14 days persist`
-
+`/watch btc drop 5000 from ath persistent daily`
   
 Comparisons are vs current price unless "from ath" is set   
 

--- a/readme.md
+++ b/readme.md
@@ -88,6 +88,15 @@ What is the ATH of a coin (only checks back to Oct 2021)
 `/ath BTC`
 
 
+**/delete**
+Delete alerts or watches.
+
+`/delete` Show list of alerts and watches with delete IDs.
+
+`/delete 1234` Delete alert or watch with ID 1234.
+
+
+
 **/help**  
 See this message.
 

--- a/secrets-example.py
+++ b/secrets-example.py
@@ -1,4 +1,4 @@
-# create your own secrets file with the Telegram bot and CC keys
+# create your own secrets file with the Telegram bot 
 
 TG_TOKEN = "xxxx:xxxxx"
-CC_API_KEY = "xxxx"
+

--- a/secrets-example.py
+++ b/secrets-example.py
@@ -1,0 +1,4 @@
+# create your own secrets file with the Telegram bot and CC keys
+
+TG_TOKEN = "xxxx:xxxxx"
+CC_API_KEY = "xxxx"

--- a/tg_bot_service.py
+++ b/tg_bot_service.py
@@ -165,8 +165,9 @@ class TgBotService(object):
                         if not persistent:
                             self.log.debug("removing completed rise watch")
                             del self.db['watches'][i]
-                        # set the most recent notify key as now epoch as int
-                        self.db['watches'][i]['last_notify'] = int(datetime.now().timestamp()) * 1000                        
+                        else:
+                            # set the most recent notify key as now epoch as int
+                            self.db['watches'][i]['last_notify'] = int(datetime.now().timestamp()) * 1000                        
 
                     else:
                         i += 1

--- a/tg_bot_service.py
+++ b/tg_bot_service.py
@@ -118,19 +118,56 @@ class TgBotService(object):
             else:
                 target = int(watch['target'])
 
+
+            # lets see if this watch is persistent
+            persistent = False
+            last_notify = 0
+            notify_frequency = 24 * 60 * 60
+            if 'persistent' in watch:
+                if watch['persistent']:
+                    persistent = True
+                if 'last_notify' in watch:
+                    last_notify = watch['last_notify']
+                    # convert last_notify from int as epoch to datetime
+                if 'notify_frequency' in watch:
+                    notify_frequency = watch['notify_frequency']
+            last_notify = datetime.fromtimestamp(last_notify/1000)
+                 
+                
+
            # do the comparison
             if watch['op'] == 'drop':
-               if currentprice < comparitorprice - target:
-                   self.api.sendMessage(f"Drop watch: {watch['fsym']} is {currentprice} {watch['tsym']} which is at least {watch['target']} lower than it was at {comparitordate_str} when it was {format_price(comparitorprice)} ", watch['chatId'])
-                   self.log.debug("removing completed drop watch")
-                   del self.db['watches'][i]
-               else:
-                   i += 1
+                if currentprice < comparitorprice - target:
+                    if persistent: # have to check it hasn't been notified too recently                        
+                        if datetime.now() - last_notify < timedelta(seconds=notify_frequency):
+                            self.log.debug("persistent watch, not notifying")
+                            i += 1
+                            continue
+                                        
+                    self.api.sendMessage(f"Drop watch: {watch['fsym']} is {currentprice} {watch['tsym']} which is at least {watch['target']} lower than it was at {comparitordate_str} when it was {format_price(comparitorprice)} ", watch['chatId'])
+                    if not persistent:
+                        self.log.debug("removing completed drop watch")
+                        del self.db['watches'][i]
+                    # set the most recent notify key as now epoch as int
+                    self.db['watches'][i]['last_notify'] = int(datetime.now().timestamp()) * 1000
+                
+                else:
+                    i += 1
             elif watch['op'] == 'rise':
                     if currentprice >  comparitorprice + target:
+                        if persistent:
+                            if datetime.now() - last_notify < timedelta(seconds=notify_frequency):
+                                self.log.debug("persistent watch, not notifying")
+                                i += 1
+                                continue
+
                         self.api.sendMessage(f"Rise watch: {watch['fsym']} is {currentprice} {watch['tsym']} which is at least {watch['target']} higher than it was at {comparitordate_str} when it was {format_price(comparitorprice)} ", watch['chatId'])
-                        self.log.debug("removing completed rise watch")
-                        del self.db['watches'][i]
+                        if not persistent:
+                            self.log.debug("removing completed rise watch")
+                            del self.db['watches'][i]
+                        # set the most recent notify key as now epoch as int
+                        self.db['watches'][i]['last_notify'] = int(datetime.now().timestamp()) * 1000                        
+
                     else:
                         i += 1
             else: # this item is invalid, delete it

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,7 @@
+# utils.py - Utility functions
+
+import hashlib
+
+def get_id(chatID, obj):
+  id = hashlib.md5(str(chatID)+str(obj).encode('utf-8')).hexdigest()
+  return id

--- a/utils.py
+++ b/utils.py
@@ -3,5 +3,6 @@
 import hashlib
 
 def get_id(chatID, obj):
-  id = hashlib.md5(str(chatID)+str(obj).encode('utf-8')).hexdigest()
+  # id = hashlib.md5(str(chatID)+str(obj).encode('utf-8')).hexdigest()
+  id = hashlib.md5((str(chatID) + str(obj)).encode('utf-8')).hexdigest()
   return id

--- a/utils.py
+++ b/utils.py
@@ -7,39 +7,33 @@ def get_id(chatID, obj):
   id = hashlib.md5((str(chatID) + str(obj)).encode('utf-8')).hexdigest()
   return id
 
-import math
 
-SECONDS_IN_MINUTE = 60  
-SECONDS_IN_HOUR = 60 * SECONDS_IN_MINUTE
-SECONDS_IN_DAY = 24 * SECONDS_IN_HOUR
-SECONDS_IN_WEEK = 7 * SECONDS_IN_DAY
-SECONDS_IN_MONTH = 30 * SECONDS_IN_DAY
+def human_format_seconds(seconds):
+    units = [(30 * 24 * 60 * 60, "month"), (7 * 24 * 60 * 60, "week"), (24 * 60 * 60, "day"), (60 * 60, "hour"), (60, "minute"), (1, "second")]
 
-ROUNDING_THRESHOLD = 0.1
+    result = ""
+    for divider, unit in units:
+        quantity = seconds // divider
+        seconds %= divider
 
-units = [
-    ("seconds", SECONDS_IN_MINUTE),
-    ("minutes", SECONDS_IN_HOUR), 
-    ("hours", SECONDS_IN_DAY),
-    ("days", SECONDS_IN_WEEK),
-    ("weeks", SECONDS_IN_MONTH)
-]
+        # Check if the remainder is within 10% of the current unit
+        if seconds >= 0.9 * divider:
+            quantity += 1
+            seconds = 0
 
-def format_duration(seconds):
-    for name, length in units:
-        unit = seconds // length
-        remainder = seconds % length
-        
-        if unit < 1:
+        # Check if the quantity is half of the current unit
+        if quantity == 0.5:
+            result += f"half a {unit} "
             continue
-            
-        if remainder > length * ROUNDING_THRESHOLD:
-            unit += 1
-            
-        if remainder > length / 2:
-            return "{:.1f} and a half {}".format(unit, name)
-            
-        if unit < 2:
-            return "about {:.1f} {}".format(unit, name)
 
-    return "{} seconds".format(seconds)
+        # Check if the quantity is about half of the current unit
+        if 0.4 <= quantity < 0.6:
+            result += f"about half a {unit} "
+            continue
+
+        # Add to the result string
+        if quantity > 0:
+            result += f"{'about ' if 0.9 <= quantity < 1 else ''}{int(quantity)} {unit if quantity == 1 else unit + 's'} "
+
+    return result.strip()
+

--- a/utils.py
+++ b/utils.py
@@ -6,3 +6,40 @@ def get_id(chatID, obj):
   # id = hashlib.md5(str(chatID)+str(obj).encode('utf-8')).hexdigest()
   id = hashlib.md5((str(chatID) + str(obj)).encode('utf-8')).hexdigest()
   return id
+
+import math
+
+SECONDS_IN_MINUTE = 60  
+SECONDS_IN_HOUR = 60 * SECONDS_IN_MINUTE
+SECONDS_IN_DAY = 24 * SECONDS_IN_HOUR
+SECONDS_IN_WEEK = 7 * SECONDS_IN_DAY
+SECONDS_IN_MONTH = 30 * SECONDS_IN_DAY
+
+ROUNDING_THRESHOLD = 0.1
+
+units = [
+    ("seconds", SECONDS_IN_MINUTE),
+    ("minutes", SECONDS_IN_HOUR), 
+    ("hours", SECONDS_IN_DAY),
+    ("days", SECONDS_IN_WEEK),
+    ("weeks", SECONDS_IN_MONTH)
+]
+
+def format_duration(seconds):
+    for name, length in units:
+        unit = seconds // length
+        remainder = seconds % length
+        
+        if unit < 1:
+            continue
+            
+        if remainder > length * ROUNDING_THRESHOLD:
+            unit += 1
+            
+        if remainder > length / 2:
+            return "{:.1f} and a half {}".format(unit, name)
+            
+        if unit < 2:
+            return "about {:.1f} {}".format(unit, name)
+
+    return "{} seconds".format(seconds)


### PR DESCRIPTION
Adds the `/delete` command which is necessary because of the persist attribute.

Adds the persist attribute to the /watch command so that watches persist and don't get automatically deleted when they fire.

Also plenty of cleanup and some prep for future enhancements